### PR TITLE
Upgrade packages and allow AC display control #24

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,10 @@
 -------------------------------------------------------------
+Next version
+
+- Added ability to control an AC device's display
+- Upgrade packages
+
+-------------------------------------------------------------
 v0.6.0
 
 - Added /rooms/actions/{action_id} patch endpoint for

--- a/homecontrol_api/devices/aircon/schemas.py
+++ b/homecontrol_api/devices/aircon/schemas.py
@@ -31,11 +31,11 @@ class ACDeviceState(BaseModel):
     eco_mode: bool
     turbo_mode: bool
     fahrenheit: bool
+    display_on: bool
 
     # Read only
     indoor_temperature: float
     outdoor_temperature: float
-    display_on: bool
 
 
 class ACDeviceStatePut(BaseModel):
@@ -48,6 +48,7 @@ class ACDeviceStatePut(BaseModel):
     eco_mode: bool
     turbo_mode: bool
     fahrenheit: bool
+    display_on: bool
 
     # Write only
     prompt_tone: bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 requires-python = ">=3.9.5"
 dependencies = [
-    "homecontrol-base@git+https://github.com/2851999/homecontrol-base@v0.2.2",
+    "homecontrol-base@git+https://github.com/2851999/homecontrol-base@v0.3.1",
     "fastapi",
     "uvicorn[standard]",
     "bcrypt",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-alembic==1.13.1
+alembic==1.13.2
 annotated-types==0.7.0
 anyio==4.4.0
 APScheduler==3.10.4
 bcrypt==4.1.3
 broadlink==0.19.0
-certifi==2024.6.2
+certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
@@ -15,7 +15,7 @@ fastapi==0.111.0
 fastapi-cli==0.0.4
 greenlet==3.0.3
 h11==0.14.0
-homecontrol-base @ git+https://github.com/2851999/homecontrol-base@7e7260762e96c92b65a53a1f75d324090139e849
+homecontrol-base @ git+https://github.com/2851999/homecontrol-base@b2ac3094dc8429ac0a5176e558515011c2cdb94c
 httpcore==1.0.5
 httptools==0.6.1
 httpx==0.27.0
@@ -26,12 +26,12 @@ Mako==1.3.5
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 mdurl==0.1.2
-msmart-ng==2024.5.4
-orjson==3.10.5
+msmart-ng==2024.7.0
+orjson==3.10.6
 pycparser==2.22
 pycryptodome==3.20.0
-pydantic==2.7.4
-pydantic_core==2.18.4
+pydantic==2.8.2
+pydantic_core==2.20.1
 Pygments==2.18.0
 PyJWT==2.8.0
 python-dotenv==1.0.1


### PR DESCRIPTION

BREAKING CHANGE: Must delete all scheduled room actions containing actions with ac_state's as well as any room actions themselves before running this.

Closes #24